### PR TITLE
Set the key to None when a NotYet error is raised

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Fixes:
 - Acquisition-unwrap each item in the aq_iter chain, as ``getSite().__parent__`` might return an object aquired from the original context which breaks the parent loop detection.
   [thet]
 
+- Prevent errors on ``moveIntIdSubscriber`` when the ``IKeyReference`` adapter
+  raises a ``NotYet``, e.g. because the object does not have a proper path.
+  [ale-rt]
+
 
 1.1.0 (2016-02-14)
 ------------------

--- a/five/intid/intid.py
+++ b/five/intid/intid.py
@@ -138,7 +138,10 @@ def moveIntIdSubscriber(ob, event):
     utilities = tuple(getAllUtilitiesRegisteredFor(IIntIds))
     if not utilities:
         return
-    key = IKeyReference(ob, None)
+    try:
+        key = IKeyReference(ob, None)
+    except NotYet:
+        key = None
 
     # Register only objects that adapt to key reference
     if key is None:


### PR DESCRIPTION
A ``NotYet`` exception is raised when the object has not a proper path.
In this case we do not want to update any reference to it.