### PR TITLE
Acquisition-unwrap each item in the aq_iter chain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Acquisition-unwrap each item in the aq_iter chain, as ``getSite().__parent__`` might return an object aquired from the original context which breaks the parent loop detection.
+  [thet]
 
 
 1.1.0 (2016-02-14)

--- a/five/intid/utils.py
+++ b/five/intid/utils.py
@@ -17,6 +17,8 @@ def aq_iter(obj, error=None):
         yield cur
         seen.add(id(aq_base(cur)))
         cur = getattr(cur, 'aq_parent', getattr(cur, '__parent__', None))
+        if cur:
+            cur = aq_inner(cur)  # unwrap from Acquisition context
         if id(aq_base(cur)) in seen:
             if error is not None:
                 raise error('__parent__ loop found')


### PR DESCRIPTION
Acquisition-unwrap each item in the aq_iter chain, as getSite().__parent__ might return an object aquired from the original context which breaks the parent loop detection.