### PR TITLE
Prevent raising NotYet in removeIntIdSubscriber

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Prevent errors on ``removeIntIdSubscriber`` when the ``IKeyReference`` adapter
+  raises a ``NotYet``, e.g. because the object does not have a proper path.
+  [ale-rt]
 
 
 1.1.1 (2016-08-19)

--- a/five/intid/intid.py
+++ b/five/intid/intid.py
@@ -114,7 +114,10 @@ def removeIntIdSubscriber(ob, event):
     utilities = tuple(getAllUtilitiesRegisteredFor(IIntIds))
     if not utilities:
         return
-    key = IKeyReference(ob, None)
+    try:
+        key = IKeyReference(ob, None)
+    except NotYet:
+        key = None
 
     # Register only objects that adapt to key reference
     if key is None:


### PR DESCRIPTION
Prevent errors on ``removeIntIdSubscriber`` when the ``IKeyReference`` adapter raises a ``NotYet``, e.g. because the object does not have a proper path.

Some background...

I had to use this patch to migrate a Plone4 site to Plone5.

A couple of examples of object removed triggering the NotYet:
```
ipdb> IKeyReference(ob, None)
*** NotYet: <SimpleItem at >
ipdb> ob.__dict__
{'_v__object_deleted__': 1, 'isAllowed': True, '__ac_local_roles__': {'admin': ['Owner']}, 'title': 'Generates RSS for folders'}
```
and:
```
ipdb> IKeyReference(ob, None)
*** NotYet: 
ipdb> ob.__dict__
{'_real': <Products.CMFCore.DirectoryView.DirectoryView object at 0x7f68fff85410>, '_dirpath': 'Products.CMFPlone:skins/cmf_legacy', '_v__object_deleted__': 1, '_objects': (), '__ac_local_roles__': {'admin': ['Owner']}, 'id': 'cmf_legacy'}
```

This is a fix similar to 513ca3ca0c1581d334dca96395ecff36c5eb320a