### PR TITLE
Encode _p_oid that can be text when the DB was migrated from py2

### DIFF
--- a/five/intid/keyreference.py
+++ b/five/intid/keyreference.py
@@ -16,6 +16,8 @@ from five.intid.utils import aq_iter
 from five.intid.site import get_root
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 
+import six
+
 
 @adapter(IPersistent)
 @implementer(IConnection)
@@ -93,6 +95,8 @@ class KeyReferenceToPersistent(KeyReferenceToPersistent):
         # object. Asking the root object on the wrong db can trigger
         # an POSKeyError.
         connection = IConnection(self.object).get_connection(self.root_dbname)
+        if isinstance(self.root_oid, six.text_type):
+            self.root_oid = self.root_oid.encode('utf8')
         return connection[self.root_oid]
 
     @property

--- a/five/intid/keyreference.py
+++ b/five/intid/keyreference.py
@@ -89,14 +89,19 @@ class KeyReferenceToPersistent(KeyReferenceToPersistent):
         self.oid = self.object._p_oid
         self.dbname = connection.db().database_name
 
+    def __setstate__(self, state):
+        for key in ('root_oid', 'oid'):
+            value = state.get(key)
+            if isinstance(value, six.text_type):
+                state[key] = value.encode('utf-8')
+        self.__dict__.update(state)
+
     @property
     def root(self):
         # It is possible that the root is not in the same db that the
         # object. Asking the root object on the wrong db can trigger
         # an POSKeyError.
         connection = IConnection(self.object).get_connection(self.root_dbname)
-        if isinstance(self.root_oid, six.text_type):
-            self.root_oid = self.root_oid.encode('utf8')
         return connection[self.root_oid]
 
     @property

--- a/news/7.bugfix
+++ b/news/7.bugfix
@@ -1,2 +1,2 @@
-Encode _p_oid that can be text when a DB was migrated from py2.
+Fix oid and root_oid that might have been accidentally converted to text when a DB was migrated from py2.
 [pbauer]

--- a/news/7.bugfix
+++ b/news/7.bugfix
@@ -1,0 +1,2 @@
+Encode _p_oid that can be text when a DB was migrated from py2.
+[pbauer]


### PR DESCRIPTION
When migrating a `Data.fs` from py2 to py3 there were cases when the `_p_oid` of a `z3c.relationfield.relation.RelationValue` object was text instead of bytes. 

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 142, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 295, in publish_module
  Module ZPublisher.WSGIPublisher, line 229, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module Products.PDBDebugMode.wsgi_runcall, line 60, in pdb_runcall
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.edit, line 58, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.edit, line 30, in handleApply
  Module z3c.form.group, line 126, in applyChanges
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 124, in subscribers
  Module zope.interface.registry, line 442, in subscribers
  Module zope.interface.adapter, line 607, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 124, in subscribers
  Module zope.interface.registry, line 442, in subscribers
  Module zope.interface.adapter, line 607, in subscribers
  Module z3c.relationfield.event, line 80, in updateRelations
  Module z3c.relationfield.event, line 23, in addRelations
  Module z3c.relationfield.event, line 141, in _setRelation
  Module zc.relation.catalog, line 557, in index_doc
  Module zc.relation.catalog, line 486, in _indexNew
  Module zc.relation.catalog, line 588, in _getValuesAndTokens
  Module z3c.relationfield.relation, line 33, in from_id
  Module plone.app.relationfield.monkey, line 13, in get_from_object
  Module z3c.relationfield.relation, line 126, in _object
  Module zope.intid, line 85, in getObject
  Module five.intid.keyreference, line 128, in __call__
  Module five.intid.keyreference, line 108, in wrapped_object
  Module five.intid.keyreference, line 101, in root
  Module ZODB.Connection, line 247, in get
  Module ZODB.mvccadapter, line 143, in load
  Module ZODB.FileStorage.FileStorage, line 564, in loadBefore
  Module ZODB.FileStorage.FileStorage, line 521, in _lookup_pos
  Module ZODB.fsIndex, line 108, in __getitem__
AssertionError
```