### PR TITLE
Workaround to fix the path of moved objects

### DIFF
--- a/five/intid/README.rst
+++ b/five/intid/README.rst
@@ -150,6 +150,8 @@ Renaming an object should not break the rewrapping of the object:
     >>> moved = intid.getObject(ob_id)
     >>> moved
     <SimpleContent at /test_folder_1_/mycont_new>
+    >>> [x.path for x in intid.ids]
+    ['/test_folder_1_/mycont_new']
 
 Nor should moving it:
 
@@ -361,4 +363,3 @@ Creating items whith a circular containment
     ...
     TypeError: ('Could not adapt', <SimpleItem at c>,
     <InterfaceClass zope.keyreference.interfaces.IKeyReference>)
-

--- a/five/intid/intid.py
+++ b/five/intid/intid.py
@@ -154,6 +154,9 @@ def moveIntIdSubscriber(ob, event):
     for utility in utilities:
         try:
             uid = utility.getId(ob)
+            # XXX this is a temporary workaround
+            utility.refs.pop(uid, None)
+            utility.ids.pop(key, None)
             utility.refs[uid] = key
             utility.ids[key] = uid
         except KeyError:

--- a/five/intid/keyreference.py
+++ b/five/intid/keyreference.py
@@ -132,11 +132,13 @@ class KeyReferenceToPersistent(KeyReferenceToPersistent):
         return self.wrapped_object
 
     def __hash__(self):
+        # XXX Maybe we should consider to use also other fields for the hash
         return hash((self.dbname,
                      self.object._p_oid,
                      ))
 
     def __cmp__(self, other):
+        # XXX This makes no sense on Python 3
         if self.key_type_id == other.key_type_id:
             return cmp((self.dbname, self.oid), (other.dbname, other.oid))
         return cmp(self.key_type_id, other.key_type_id)

--- a/news/8.fixed
+++ b/news/8.fixed
@@ -1,0 +1,1 @@
+Properly update the persistent objects stored in the initid utility btrees [ale-rt]


### PR DESCRIPTION
This PR wants to provide a workaround for the issue described in https://github.com/plone/plone.api/issues/430.
The reason why this PR is needed is that moving an object does not actually updates the object stored in the intid persistent utility because the relevant BTrees do not recognize that the key is changed (probably because the computed `__hash__` does not change).

Closes https://github.com/plone/plone.api/issues/430