### PR TITLE
Catch KeyError when traversing to fix creating relations during Copy&Paste in Zope 4

### DIFF
--- a/five/intid/keyreference.py
+++ b/five/intid/keyreference.py
@@ -110,7 +110,7 @@ class KeyReferenceToPersistent(KeyReferenceToPersistent):
             return self.object
         try:
             obj = self.root.unrestrictedTraverse(self.path)
-        except (NotFound, AttributeError,):
+        except (NotFound, AttributeError, KeyError):
             return self.object
         chain = aq_chain(obj)
         # Try to ensure we have a request at the acquisition root

--- a/five/intid/keyreference.py
+++ b/five/intid/keyreference.py
@@ -108,9 +108,8 @@ class KeyReferenceToPersistent(KeyReferenceToPersistent):
     def wrapped_object(self):
         if self.path is None:
             return self.object
-        try:
-            obj = self.root.unrestrictedTraverse(self.path)
-        except (NotFound, AttributeError, KeyError):
+        obj = self.root.unrestrictedTraverse(self.path, None)
+        if obj is None:
             return self.object
         chain = aq_chain(obj)
         # Try to ensure we have a request at the acquisition root

--- a/news/12.bugfix
+++ b/news/12.bugfix
@@ -1,0 +1,3 @@
+Also catch KeyError when traversing to fix creating relations during Copy&Paste in Zope 4.
+Fixes https://github.com/plone/Products.CMFPlone/issues/2866
+[pbauer]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2866