### PR TITLE
Speedup object lookup by up factor ~80

### DIFF
--- a/news/14.bugfix
+++ b/news/14.bugfix
@@ -1,0 +1,2 @@
+When looking up back-references the lookup using unrestrictedTraverse was way to slow.
+A simplified traverse speeds up the lookup by up 80x. [jensens, 2silver]


### PR DESCRIPTION
thanks to FH St.Pölten and @2silver we found this enormous speedup.
When looking up back-references  the lookup using `unrestrictedTraverse` was way to slow. 
A simplified traverse  speeds up the lookup by up 80x.