### PR TITLE
Fixed ModuleNotFoundError: No module named 'App.class_init' on Zope 5.

### DIFF
--- a/five/intid/intid.py
+++ b/five/intid/intid.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from Acquisition import Explicit
-from App.class_init import InitializeClass
+from AccessControl.class_init import InitializeClass
 from zope.component import getAllUtilitiesRegisteredFor
 from zope.event import notify
 from zope.interface import implementer

--- a/news/15.bugfix
+++ b/news/15.bugfix
@@ -1,0 +1,2 @@
+Fixed ModuleNotFoundError: No module named 'App.class_init' on Zope 5.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/five.intid/issues/15